### PR TITLE
[fix] Node.jsのバージョンを固定

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,9 @@
     "@babel/plugin-proposal-private-methods": "^7.18.6",
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "webpack-dev-server": "^3"
+  },
+  "engines": {
+    "node": "18.x",
+    "yarn": "1.x"
   }
 }


### PR DESCRIPTION
Herokuへのpushが失敗するのを修正するために行いました。